### PR TITLE
feat: add experimental Linktree import

### DIFF
--- a/components/AnalyticsPage.tsx
+++ b/components/AnalyticsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import {
   ArrowLeft,
@@ -34,6 +34,8 @@ type AnalyticsEvent = {
   language: string | null;
   screen_w: number | null;
   screen_h: number | null;
+  viewport_w: number | null;
+  viewport_h: number | null;
   visitor_id: string | null;
   session_id: string | null;
   duration_seconds: number | null;
@@ -84,50 +86,53 @@ const AnalyticsPage: React.FC = () => {
       .finally(() => setInitialLoading(false));
   }, []);
 
-  const fetchAnalytics = async (customDays?: number) => {
-    const daysToFetch = customDays ?? days;
-    if (!projectUrl || !dbPassword) {
-      setError('Please enter your Supabase URL and database password');
-      return;
-    }
-
-    setLoading(true);
-    setError(null);
-
-    try {
-      const res = await fetch('/__openbento/analytics/fetch', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ projectUrl, dbPassword, days: daysToFetch }),
-      });
-
-      const data = await res.json();
-      if (data.ok) {
-        setEvents(data.events || []);
-        setIsConfigured(true);
-      } else {
-        setError(data.error || 'Failed to fetch analytics');
+  const fetchAnalytics = useCallback(
+    async (customDays?: number) => {
+      const daysToFetch = customDays ?? days;
+      if (!projectUrl || !dbPassword) {
+        setError('Please enter your Supabase URL and database password');
+        return;
       }
-    } catch (e) {
-      setError('Network error: ' + (e as Error).message);
-    } finally {
-      setLoading(false);
-    }
-  };
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const res = await fetch('/__openbento/analytics/fetch', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ projectUrl, dbPassword, days: daysToFetch }),
+        });
+
+        const data = await res.json();
+        if (data.ok) {
+          setEvents(data.events || []);
+          setIsConfigured(true);
+        } else {
+          setError(data.error || 'Failed to fetch analytics');
+        }
+      } catch (e) {
+        setError('Network error: ' + (e as Error).message);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [days, projectUrl, dbPassword]
+  );
 
   // Auto-fetch when config is ready
   useEffect(() => {
     if (!initialLoading && projectUrl && dbPassword && !isConfigured) {
       fetchAnalytics();
     }
-  }, [initialLoading, projectUrl, dbPassword]);
+  }, [initialLoading, projectUrl, dbPassword, isConfigured, fetchAnalytics]);
 
   // Auto-refresh when days change (if already configured)
   useEffect(() => {
     if (isConfigured && projectUrl && dbPassword) {
       fetchAnalytics(days);
     }
-  }, [days]);
+  }, [days, isConfigured, projectUrl, dbPassword, fetchAnalytics]);
 
   // Compute analytics stats
   const stats = useMemo(() => {

--- a/components/Builder.tsx
+++ b/components/Builder.tsx
@@ -572,6 +572,23 @@ const Builder: React.FC<BuilderProps> = ({ onBack }) => {
     [profile, blocks, setSiteData, autoSave]
   );
 
+  const applyImportedBento = useCallback(
+    (newBento: SavedBento) => {
+      const nextGridVersion = newBento.data.gridVersion ?? GRID_VERSION;
+      const normalizedBlocks = ensureBlocksHavePositions(newBento.data.blocks);
+
+      setActiveBento(newBento);
+      setGridVersion(nextGridVersion);
+      setActiveBentoId(newBento.id);
+      reset({
+        profile: newBento.data.profile,
+        blocks: normalizedBlocks,
+      });
+      setEditingBlockId(null);
+    },
+    [reset]
+  );
+
   // Note: Block positioning is handled when blocks are created (addBlock function)
   // No automatic repositioning to avoid conflicts with user-placed blocks
 
@@ -2229,7 +2246,8 @@ const Builder: React.FC<BuilderProps> = ({ onBack }) => {
           }
         }}
         blocks={blocks}
-        setBlocks={handleSetBlocks}
+        onBlocksChange={handleSetBlocks}
+        onBentoImported={applyImportedBento}
       />
 
       {/* 4. AVATAR CROP MODAL */}
@@ -2269,13 +2287,7 @@ const Builder: React.FC<BuilderProps> = ({ onBack }) => {
       <AIGeneratorModal
         isOpen={showAIGeneratorModal}
         onClose={() => setShowAIGeneratorModal(false)}
-        onBentoImported={(newBento) => {
-          // Reload the app with the new bento
-          setActiveBento(newBento);
-          handleSetProfile(newBento.data.profile);
-          handleSetBlocks(newBento.data.blocks);
-          setGridVersion(newBento.data.gridVersion ?? GRID_VERSION);
-        }}
+        onBentoImported={applyImportedBento}
       />
 
       {/* 7. DEPLOY MODAL */}

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -16,7 +16,7 @@ import {
   Database,
   Globe,
 } from 'lucide-react';
-import type { SocialPlatform, UserProfile, BlockData } from '../types';
+import type { SocialPlatform, UserProfile, BlockData, SavedBento } from '../types';
 import { AVATAR_PLACEHOLDER } from '../constants';
 import ImageCropModal from './ImageCropModal';
 import {
@@ -25,6 +25,9 @@ import {
   SOCIAL_PLATFORM_OPTIONS,
   formatFollowerCount,
 } from '../socialPlatforms';
+import { importLinktreeToBento } from '../services/linktreeImportService';
+
+const ENABLE_IMPORT = import.meta.env.VITE_ENABLE_IMPORT === 'true';
 
 type SettingsModalProps = {
   isOpen: boolean;
@@ -36,6 +39,7 @@ type SettingsModalProps = {
   // For raw JSON editing
   blocks?: BlockData[];
   onBlocksChange?: (blocks: BlockData[]) => void;
+  onBentoImported?: (bento: SavedBento) => void;
 };
 
 type TabType = 'general' | 'social' | 'seo' | 'analytics' | 'json';
@@ -49,6 +53,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   onBentoNameChange,
   blocks,
   onBlocksChange,
+  onBentoImported,
 }) => {
   const avatarInputRef = useRef<HTMLInputElement>(null);
   const [pendingAvatarSrc, setPendingAvatarSrc] = useState<string | null>(null);
@@ -62,6 +67,12 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   // JSON editor state
   const [jsonText, setJsonText] = useState('');
   const [jsonError, setJsonError] = useState<string | null>(null);
+  const [linktreeInput, setLinktreeInput] = useState('');
+  const [linktreeImportState, setLinktreeImportState] = useState<{
+    status: 'loading' | 'success' | 'error';
+    message: string;
+    details?: string[];
+  } | null>(null);
 
   // Supabase Analytics state
   const [supabaseProjectUrl, setSupabaseProjectUrl] = useState('');
@@ -254,6 +265,31 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
     }
   };
 
+  const handleLinktreeImport = async () => {
+    if (!onBentoImported || !linktreeInput.trim()) return;
+
+    setLinktreeImportState({
+      status: 'loading',
+      message: 'Importing Linktree content...',
+    });
+
+    try {
+      const result = await importLinktreeToBento(linktreeInput);
+      onBentoImported(result.bento);
+      setLinktreeInput('');
+      setLinktreeImportState({
+        status: 'success',
+        message: `${result.importedCount} link(s) imported into a new Bento.`,
+        details: result.warnings,
+      });
+    } catch (error) {
+      setLinktreeImportState({
+        status: 'error',
+        message: (error as Error).message || 'Linktree import failed.',
+      });
+    }
+  };
+
   const tabs: { id: TabType; label: string; icon: React.ReactNode }[] = [
     { id: 'general', label: 'General', icon: <User size={16} /> },
     { id: 'social', label: 'Social', icon: <Share2 size={16} /> },
@@ -349,6 +385,78 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
                           Used as filename when exporting JSON
                         </p>
                       </div>
+
+                      {ENABLE_IMPORT && onBentoImported && (
+                        <div className="p-4 bg-amber-50 border border-amber-200 rounded-xl space-y-3">
+                          <div>
+                            <label className="block text-[10px] font-bold text-amber-700 uppercase tracking-wider mb-1.5">
+                              Experimental Import
+                            </label>
+                            <p className="text-sm font-semibold text-gray-900">
+                              Import from Linktree
+                            </p>
+                            <p className="text-xs text-amber-800 mt-1">
+                              This feature is experimental. Some links, media, or custom sections
+                              may not be imported correctly.
+                            </p>
+                          </div>
+
+                          <div className="flex flex-col sm:flex-row gap-2">
+                            <input
+                              type="text"
+                              aria-label="Linktree URL or username"
+                              value={linktreeInput}
+                              onChange={(e) => setLinktreeInput(e.target.value)}
+                              placeholder="https://linktr.ee/yourname or yourname"
+                              className="flex-1 bg-white border border-amber-200 rounded-lg px-3 py-2 text-sm text-gray-800 focus:ring-2 focus:ring-amber-400/40 focus:border-amber-400 focus:outline-none transition-all"
+                            />
+                            <button
+                              type="button"
+                              aria-label="Import from Linktree"
+                              onClick={handleLinktreeImport}
+                              disabled={
+                                !linktreeInput.trim() || linktreeImportState?.status === 'loading'
+                              }
+                              className="px-4 py-2 rounded-lg bg-gray-900 text-white text-sm font-semibold hover:bg-black transition-colors disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center justify-center gap-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            >
+                              {linktreeImportState?.status === 'loading' ? (
+                                <>
+                                  <Loader2 size={16} className="animate-spin" />
+                                  Importing...
+                                </>
+                              ) : (
+                                <>
+                                  <Upload size={16} />
+                                  Import Linktree
+                                </>
+                              )}
+                            </button>
+                          </div>
+
+                          {linktreeImportState && (
+                            <div
+                              className={`rounded-lg border px-3 py-2 ${
+                                linktreeImportState.status === 'error'
+                                  ? 'bg-red-50 border-red-200 text-red-700'
+                                  : linktreeImportState.status === 'success'
+                                    ? 'bg-green-50 border-green-200 text-green-700'
+                                    : 'bg-white border-amber-200 text-amber-800'
+                              }`}
+                            >
+                              <p className="text-sm font-medium">{linktreeImportState.message}</p>
+                              {linktreeImportState.details?.length ? (
+                                <div className="mt-1 space-y-1">
+                                  {linktreeImportState.details.map((detail) => (
+                                    <p key={detail} className="text-xs">
+                                      {detail}
+                                    </p>
+                                  ))}
+                                </div>
+                              ) : null}
+                            </div>
+                          )}
+                        </div>
+                      )}
                     </section>
                   )}
 

--- a/docs/builder/configuration.md
+++ b/docs/builder/configuration.md
@@ -7,6 +7,7 @@ OpenBento can be customized through environment variables.
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `VITE_ENABLE_LANDING` | Show landing page before builder | `false` |
+| `VITE_ENABLE_IMPORT` | Enable experimental import actions in Settings, including Linktree import | `false` |
 
 ## Landing Page
 
@@ -25,6 +26,24 @@ VITE_ENABLE_LANDING=true npm run dev
 ```bash
 VITE_ENABLE_LANDING=true npm run build
 ```
+
+## Experimental Import
+
+Import actions in **Settings** are disabled by default.
+
+To enable the experimental import UI:
+
+```bash
+VITE_ENABLE_IMPORT=true npm run dev
+```
+
+Or for a production build:
+
+```bash
+VITE_ENABLE_IMPORT=true npm run build
+```
+
+This import flow is experimental. Imported Linktree content may require manual cleanup after import.
 
 ## Data Storage
 

--- a/services/linktreeImportService.ts
+++ b/services/linktreeImportService.ts
@@ -1,0 +1,324 @@
+import { AVATAR_PLACEHOLDER } from '../constants';
+import {
+  extractHandleFromUrl,
+  inferSocialPlatformFromUrl,
+  normalizeSocialHandle,
+} from '../socialPlatforms';
+import type { BlockData, SavedBento, SocialAccount, UserProfile } from '../types';
+import { BlockType } from '../types';
+import { GRID_VERSION, importBentoFromJSON, type BentoJSON } from './storageService';
+
+type LinktreeSocialLink = {
+  url?: string;
+  profileUrl?: string;
+  href?: string;
+  link?: string;
+  type?: string;
+  platform?: string;
+};
+
+type LinktreePageProps = {
+  username?: string;
+  pageTitle?: string;
+  description?: string | null;
+  metaTitle?: string | null;
+  metaDescription?: string | null;
+  customAvatar?: string | null;
+  socialLinks?: LinktreeSocialLink[];
+  seoSchema?: {
+    mainEntity?: {
+      sameAs?: string[];
+    };
+  };
+  account?: {
+    username?: string;
+    pageTitle?: string;
+    description?: string | null;
+    profilePictureUrl?: string | null;
+    customAvatar?: string | null;
+    dynamicMetaTitle?: string | null;
+    dynamicMetaDescription?: string | null;
+    socialLinks?: LinktreeSocialLink[];
+    links?: Array<Record<string, unknown>>;
+    theme?: {
+      background?: {
+        color?: string;
+      };
+      buttonStyle?: {
+        backgroundStyle?: {
+          color?: string;
+        };
+        textStyle?: {
+          color?: string;
+        };
+      };
+      typeface?: {
+        color?: string;
+      };
+    };
+  };
+};
+
+export type LinktreeImportResult = {
+  bento: SavedBento;
+  importedCount: number;
+  skippedCount: number;
+  warnings: string[];
+};
+
+const normalizeLinktreeInput = (input: string): string => {
+  const trimmed = input.trim();
+  if (!trimmed) throw new Error('Enter a Linktree URL or username.');
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    const parsed = new URL(trimmed);
+    const hostname = parsed.hostname.toLowerCase();
+    if (hostname !== 'linktr.ee' && hostname !== 'www.linktr.ee') {
+      throw new Error('Only linktr.ee URLs are supported.');
+    }
+    const username = parsed.pathname.split('/').filter(Boolean)[0];
+    if (!username) throw new Error('The Linktree URL must include a username.');
+    return `https://linktr.ee/${username}`;
+  }
+
+  const username = trimmed
+    .replace(/^@/, '')
+    .replace(/^https?:\/\/(www\.)?linktr\.ee\//i, '')
+    .split(/[/?#]/)[0];
+
+  if (!username) throw new Error('The Linktree username is invalid.');
+  return `https://linktr.ee/${username}`;
+};
+
+const isHttpUrl = (value: unknown): value is string => {
+  if (typeof value !== 'string') return false;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+const pickFirstText = (...values: unknown[]): string => {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return '';
+};
+
+const pickFirstUrl = (...values: unknown[]): string | undefined => {
+  for (const value of values) {
+    if (isHttpUrl(value)) return value;
+  }
+  return undefined;
+};
+
+const sanitizeImportedTitle = (value: string): string => {
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  return trimmed.replace(/\s+\|\s*Linktree$/i, '').trim();
+};
+
+const collectSocialUrls = (pageProps: LinktreePageProps): string[] => {
+  const urls = new Set<string>();
+  const socialLists = [pageProps.socialLinks, pageProps.account?.socialLinks];
+
+  for (const list of socialLists) {
+    for (const item of list || []) {
+      const url = pickFirstUrl(item.url, item.profileUrl, item.href, item.link);
+      if (url) urls.add(url);
+    }
+  }
+
+  for (const sameAs of pageProps.seoSchema?.mainEntity?.sameAs || []) {
+    if (isHttpUrl(sameAs)) urls.add(sameAs);
+  }
+
+  return Array.from(urls);
+};
+
+const extractSocialAccounts = (pageProps: LinktreePageProps): SocialAccount[] => {
+  const dedupe = new Map<string, SocialAccount>();
+
+  for (const url of collectSocialUrls(pageProps)) {
+    const platform = inferSocialPlatformFromUrl(url);
+    if (!platform) continue;
+
+    const rawHandle = extractHandleFromUrl(platform, url) || url;
+    const handle = normalizeSocialHandle(platform, rawHandle);
+    if (!handle) continue;
+
+    dedupe.set(platform, { platform, handle });
+  }
+
+  return Array.from(dedupe.values());
+};
+
+const createLinkBlocks = (pageProps: LinktreePageProps) => {
+  const links = Array.isArray(pageProps.account?.links) ? pageProps.account.links : [];
+  const buttonColor = pageProps.account?.theme?.buttonStyle?.backgroundStyle?.color || '#111827';
+  const textColorHex = pageProps.account?.theme?.buttonStyle?.textStyle?.color || '#ffffff';
+
+  let importedCount = 0;
+  let skippedCount = 0;
+
+  const blocks = links.flatMap((link, index) => {
+    const url = pickFirstUrl(link.url, link.href);
+    const title = pickFirstText(link.title);
+    const isActive = link.isActive !== false;
+    const isLocked = Boolean(link.isLocked || link.locked);
+
+    if (!url || !title || !isActive || isLocked) {
+      skippedCount += 1;
+      return [];
+    }
+
+    importedCount += 1;
+
+    let hostname = '';
+    try {
+      hostname = new URL(url).hostname.replace(/^www\./, '');
+    } catch {
+      hostname = 'External link';
+    }
+
+    return [
+      {
+        id: `linktree-link-${index}`,
+        type: BlockType.LINK,
+        title,
+        subtext: hostname,
+        content: url,
+        colSpan: 9,
+        rowSpan: 3,
+        gridColumn: 1,
+        gridRow: importedCount * 3 - 2,
+        customBackground: buttonColor,
+        textColor: textColorHex.toLowerCase() === '#000000' ? 'text-gray-900' : 'text-white',
+      } satisfies BlockData,
+    ];
+  });
+
+  return { blocks, importedCount, skippedCount };
+};
+
+const createProfile = (
+  pageProps: LinktreePageProps,
+  socialAccounts: SocialAccount[]
+): UserProfile => {
+  const title = sanitizeImportedTitle(
+    pickFirstText(
+      pageProps.account?.pageTitle,
+      pageProps.pageTitle,
+      pageProps.account?.dynamicMetaTitle,
+      pageProps.metaTitle,
+      pageProps.account?.username,
+      pageProps.username,
+      'Imported Linktree'
+    )
+  );
+  const description = pickFirstText(
+    pageProps.account?.description,
+    pageProps.description,
+    pageProps.account?.dynamicMetaDescription,
+    pageProps.metaDescription
+  );
+  const avatarUrl = pickFirstUrl(
+    pageProps.account?.profilePictureUrl,
+    pageProps.account?.customAvatar,
+    pageProps.customAvatar
+  );
+
+  return {
+    name: title || 'Imported Linktree',
+    bio: description,
+    avatarUrl:
+      avatarUrl && !avatarUrl.includes('/blank-avatar.svg') ? avatarUrl : AVATAR_PLACEHOLDER,
+    theme: 'light',
+    primaryColor: 'blue',
+    showBranding: true,
+    showSocialInHeader: socialAccounts.length > 0,
+    showFollowerCount: false,
+    socialAccounts,
+    analytics: { enabled: false, supabaseUrl: '' },
+    backgroundColor: pageProps.account?.theme?.background?.color || '#f8fafc',
+    openGraph: {
+      title: title || 'Imported Linktree',
+      description,
+      image: avatarUrl && !avatarUrl.includes('/blank-avatar.svg') ? avatarUrl : undefined,
+      siteName: 'Linktree import',
+      twitterCardType: 'summary_large_image',
+    },
+  };
+};
+
+const buildBentoJsonFromLinktree = (pageProps: LinktreePageProps) => {
+  const socialAccounts = extractSocialAccounts(pageProps);
+  const { blocks: linkBlocks, importedCount, skippedCount } = createLinkBlocks(pageProps);
+  const profile = createProfile(pageProps, socialAccounts);
+  const warnings = [
+    'Experimental import: some Linktree elements may need manual cleanup after import.',
+  ];
+
+  if (skippedCount > 0) {
+    warnings.push(`${skippedCount} item(s) could not be imported automatically.`);
+  }
+  if (socialAccounts.length === 0) {
+    warnings.push('No supported social accounts were detected on this Linktree page.');
+  }
+
+  const json: BentoJSON = {
+    id: `linktree_${Date.now()}`,
+    name: `${profile.name.replace(/^@/, '').trim() || 'Linktree Import'} Bento`,
+    version: '1.0',
+    gridVersion: GRID_VERSION,
+    profile,
+    blocks: linkBlocks,
+    exportedAt: Date.now(),
+  };
+
+  return { json, importedCount, skippedCount, warnings };
+};
+
+export const importLinktreeToBento = async (input: string): Promise<LinktreeImportResult> => {
+  if (import.meta.env.VITE_ENABLE_IMPORT !== 'true') {
+    throw new Error('Import feature is disabled. Set VITE_ENABLE_IMPORT=true to enable it.');
+  }
+
+  const sourceUrl = normalizeLinktreeInput(input);
+  const endpoint = `/__openbento/import/linktree?url=${encodeURIComponent(sourceUrl)}`;
+
+  let response: Response;
+  try {
+    response = await fetch(endpoint);
+  } catch (error) {
+    throw new Error(
+      `Unable to reach the Linktree import service. ${(error as Error).message || ''}`.trim()
+    );
+  }
+
+  const payload = (await response.json().catch(() => null)) as {
+    ok?: boolean;
+    error?: string;
+    pageProps?: LinktreePageProps;
+  } | null;
+
+  if (!response.ok || !payload?.ok || !payload.pageProps) {
+    if (response.status === 404) {
+      throw new Error('Linktree import is unavailable in this environment.');
+    }
+    throw new Error(payload?.error || 'Failed to fetch this Linktree page.');
+  }
+
+  const { json, importedCount, skippedCount, warnings } = buildBentoJsonFromLinktree(
+    payload.pageProps
+  );
+
+  return {
+    bento: importBentoFromJSON(json),
+    importedCount,
+    skippedCount,
+    warnings,
+  };
+};

--- a/services/storageService.ts
+++ b/services/storageService.ts
@@ -305,6 +305,7 @@ export const downloadBentoJSON = (bento: SavedBento): void => {
 // Import a bento from JSON
 export const importBentoFromJSON = (json: BentoJSON): SavedBento => {
   const now = Date.now();
+  const profile = json.profile || ({} as UserProfile);
 
   const newBento: SavedBento = {
     id: generateId(), // Always generate new ID to avoid conflicts
@@ -314,14 +315,15 @@ export const importBentoFromJSON = (json: BentoJSON): SavedBento => {
     data: {
       gridVersion: json.gridVersion ?? GRID_VERSION,
       profile: {
-        name: json.profile?.name || 'My Bento',
-        bio: json.profile?.bio || '',
-        avatarUrl: json.profile?.avatarUrl || AVATAR_PLACEHOLDER,
-        theme: json.profile?.theme || 'light',
-        primaryColor: json.profile?.primaryColor || 'blue',
-        showBranding: json.profile?.showBranding ?? true,
-        analytics: json.profile?.analytics || { enabled: false, supabaseUrl: '' },
-        socialAccounts: json.profile?.socialAccounts || [],
+        ...profile,
+        name: profile.name || 'My Bento',
+        bio: profile.bio || '',
+        avatarUrl: profile.avatarUrl || AVATAR_PLACEHOLDER,
+        theme: profile.theme || 'light',
+        primaryColor: profile.primaryColor || 'blue',
+        showBranding: profile.showBranding ?? true,
+        analytics: profile.analytics || { enabled: false, supabaseUrl: '' },
+        socialAccounts: profile.socialAccounts || [],
       },
       blocks: (json.blocks || []).map((b) => ({
         ...b,

--- a/socialPlatforms.ts
+++ b/socialPlatforms.ts
@@ -16,6 +16,7 @@ import {
   Link as LinkIcon,
   Linkedin,
   MessageCircle,
+  Music,
   Newspaper,
   Phone,
   Pin,
@@ -280,7 +281,7 @@ export const SOCIAL_PLATFORM_OPTIONS: SocialPlatformOption[] = [
   {
     id: 'spotify',
     label: 'Spotify',
-    icon: SiSpotify,
+    icon: Music,
     brandIcon: SiSpotify,
     brandColor: '#1DB954',
     placeholder: 'spotify username',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -114,6 +114,37 @@ const randomPassword = () => {
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
+const normalizeLinktreeUrl = (input: string): string | null => {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  try {
+    const parsed = /^https?:\/\//i.test(trimmed)
+      ? new URL(trimmed)
+      : new URL(`https://linktr.ee/${trimmed.replace(/^@/, '')}`);
+    const hostname = parsed.hostname.toLowerCase();
+    if (hostname !== 'linktr.ee' && hostname !== 'www.linktr.ee') return null;
+    const username = parsed.pathname.split('/').filter(Boolean)[0];
+    if (!username) return null;
+    return `https://linktr.ee/${username}`;
+  } catch {
+    return null;
+  }
+};
+
+const extractNextData = (html: string) => {
+  const match = html.match(
+    /<script id="__NEXT_DATA__" type="application\/json"[^>]*>([\s\S]*?)<\/script>/
+  );
+  if (!match) return null;
+
+  try {
+    return JSON.parse(match[1]);
+  } catch {
+    return null;
+  }
+};
+
 // Simple setup using just DB password (no CLI login needed)
 const simpleSupabaseSetupPlugin = (): Plugin => {
   return {
@@ -142,6 +173,53 @@ const simpleSupabaseSetupPlugin = (): Plugin => {
             const body = await readJsonBody(req);
             fs.writeFileSync(configPath, JSON.stringify(body, null, 2));
             json(res, 200, { ok: true });
+            return;
+          }
+
+          if (req.method === 'GET' && req.url.startsWith('/__openbento/import/linktree')) {
+            const requestUrl = new URL(req.url, 'http://localhost');
+            const sourceUrl = normalizeLinktreeUrl(requestUrl.searchParams.get('url') || '');
+
+            if (!sourceUrl) {
+              json(res, 400, { ok: false, error: 'Invalid Linktree URL.' });
+              return;
+            }
+
+            try {
+              const upstream = await fetch(sourceUrl, {
+                headers: {
+                  'user-agent': 'OpenBento Linktree Import',
+                  accept: 'text/html,application/xhtml+xml',
+                },
+              });
+
+              if (!upstream.ok) {
+                json(res, upstream.status, {
+                  ok: false,
+                  error: `Linktree returned ${upstream.status}.`,
+                });
+                return;
+              }
+
+              const html = await upstream.text();
+              const nextData = extractNextData(html);
+              const pageProps = nextData?.props?.pageProps;
+
+              if (!pageProps?.account) {
+                json(res, 422, {
+                  ok: false,
+                  error: 'Unable to extract importable data from this Linktree page.',
+                });
+                return;
+              }
+
+              json(res, 200, { ok: true, pageProps, sourceUrl });
+            } catch (error) {
+              json(res, 500, {
+                ok: false,
+                error: `Failed to fetch Linktree page: ${(error as Error).message}`,
+              });
+            }
             return;
           }
 


### PR DESCRIPTION
## Description

Adds an experimental Linktree import flow in `Settings`, gated behind `VITE_ENABLE_IMPORT=true`.

This PR:
- adds a new Linktree import action in Settings with explicit experimental messaging
- imports Linktree title, description, profile picture, main links, and supported social accounts into a new Bento
- keeps imported social accounts in the profile without auto-adding them as Bento social blocks
- fixes the builder import flow so imported avatar/bio update immediately after import
- preserves more profile fields when importing Bento JSON
- documents the new `VITE_ENABLE_IMPORT` environment variable
- fixes existing lint/type-check issues encountered while validating the change

## Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
<!-- Fixes #(issue number) -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [x] 🎨 Style/UI improvement
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🔧 Configuration/build changes

## Checklist

- [x] My code follows the project's code style
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have run `npm run type-check` with no errors
- [x] I have tested my changes locally with `npm run dev`
- [x] I have added/updated documentation if needed
- [x] My changes generate no new warnings

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->
![import_linktree](https://github.com/user-attachments/assets/c40613b5-243a-449c-b8bd-75c301bf21a7)


## Additional Notes

- The feature is disabled by default and only appears when `VITE_ENABLE_IMPORT=true`.
- Linktree import relies on parsing public page data and is intentionally labeled experimental because some content may still require manual cleanup after import.
